### PR TITLE
use proper filename scheme for portfolio results

### DIFF
--- a/prepare_pacta_indices.R
+++ b/prepare_pacta_indices.R
@@ -138,11 +138,11 @@ combined <-
 
 combined %>%
   filter(!grepl("Global Corp Bond", portfolio_name)) %>%
-  saveRDS(file.path(output_dir, "Indices_equity_portfolio.rds"))
+  saveRDS(file.path(output_dir, "Indices_equity_results_portfolio.rds"))
 
 combined %>%
   filter(grepl("Global Corp Bond", portfolio_name)) %>%
-  saveRDS(file.path(output_dir, "Indices_bonds_portfolio.rds"))
+  saveRDS(file.path(output_dir, "Indices_bonds_results_portfolio.rds"))
 
 # -------------------------------------------------------------------------
 # output emissions data


### PR DESCRIPTION
co-dependent on: https://github.com/RMI-PACTA/workflow.transition.monitor/pull/147

related to https://github.com/RMI-PACTA/workflow.transition.monitor/pull/144

PACTA results files are typically names `[equity|bonds]_results_portfolio.rds` not `[equity|bonds]_portfolio.rds`

as seen here
https://github.com/RMI-PACTA/workflow.transition.monitor/blob/584ed0d6ffba4d4c024abdaa1e018aebc138751f/web_tool_script_2.R#L135
and here
https://github.com/RMI-PACTA/workflow.transition.monitor/blob/584ed0d6ffba4d4c024abdaa1e018aebc138751f/web_tool_script_2.R#L238

This will also require a change in [workflow.transition.monitor/web_tool_script_3.R](https://github.com/RMI-PACTA/workflow.transition.monitor/blob/main/web_tool_script_3.R) here
https://github.com/RMI-PACTA/workflow.transition.monitor/blob/584ed0d6ffba4d4c024abdaa1e018aebc138751f/web_tool_script_3.R#L139-L141

both of the changes/PRs should be coordinated