### PR TITLE
Remove `pacta.data.scraping` from `imports.R`

### DIFF
--- a/imports.R
+++ b/imports.R
@@ -2,7 +2,6 @@ requirements <- c(
   "cli",
   "dplyr",
   "fs",
-  "pacta.data.scraping",
   "purrr",
   "readr",
   "yaml"


### PR DESCRIPTION
It seems as though this package dependency (along with other PACTA package dependencies) are handled already in the `Dockerfile`, so it is unnecessary to also install them in `imports.R`