### PR TITLE
Depend on `pacta.portfolio.allocate`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM rocker/tidyverse
 
-ARG GITHUB_PAT
-ENV GITHUB_PAT $GITHUB_PAT
-
 # install system dependencies
 ARG SYS_DEPS="\
     git \
@@ -19,7 +16,7 @@ RUN Rscript -e "install.packages('remotes')"
 # install PACTA R packages
 RUN Rscript -e "remotes::install_github(repo = 'RMI-PACTA/pacta.data.scraping')"
 RUN Rscript -e "remotes::install_github(repo = 'RMI-PACTA/pacta.portfolio.import')"
-RUN Rscript -e "remotes::install_github(repo = 'RMI-PACTA/pacta.portfolio.analysis')"
+RUN Rscript -e "remotes::install_github(repo = 'RMI-PACTA/pacta.portfolio.allocate')"
 RUN Rscript -e "remotes::install_github(repo = 'RMI-PACTA/pacta.portfolio.audit')"
 RUN Rscript -e "remotes::install_github(repo = 'RMI-PACTA/pacta.portfolio.utils')"
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ The simplest way to run the data preparation process is by using docker.
 First, create a `.env` file in the root directory with the following fields: 
 
 ``` env
-GITHUB_PAT=**********
 TRANSITION_MONITOR_PATH=PATH/TO/workflow.transition.monitor
 PACTA_DATA_PATH=PATH/TO/pacta-data/2021Q4
 ```


### PR DESCRIPTION
A fun side-effect of this, is that we no longer install any private repositories, so we can get rid of all the GITHUB_PAT stuff