### PR TITLE
Update `docker-compose` to 2022Q4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
       - .env
     volumes:
       - ${TRANSITION_MONITOR_PATH}:/home/bound
-      - ${PACTA_DATA_PATH}:/home/pacta-data/2021Q4
+      - ${PACTA_DATA_PATH}:/home/pacta-data/2022Q4


### PR DESCRIPTION
We should probably make it so we don't need to hard-code the quarter into the mount location, but for now I want to make as few changes as necessary to get this running. 