### PR TITLE
Bump `rmi_pacta` base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # https://packagemanager.rstudio.com/client/#/repos/2/overview
 # https://packagemanager.rstudio.com/cran/__linux__/jammy/2023-03-31+MbiAEzHt
 
-ARG BASE_IMAGE=transitionmonitordockerregistry.azurecr.io/rmi_pacta:0.0.0.9081
+ARG BASE_IMAGE=transitionmonitordockerregistry.azurecr.io/rmi_pacta:2021q4_1.0.0
 FROM --platform=linux/amd64 $BASE_IMAGE
 ARG CRAN_REPO="https://packagemanager.rstudio.com/cran/__linux__/jammy/2023-03-31+MbiAEzHt"
 RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site"


### PR DESCRIPTION
This PR bumps the `rmi_pacta` base image version to the latest stable version (that is currently on production)