### PR TITLE
update CRAN repo pinned data and URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 ARG BASE_IMAGE=transitionmonitordockerregistry.azurecr.io/rmi_pacta:2021q4_1.0.0
 FROM --platform=linux/amd64 $BASE_IMAGE
-ARG CRAN_REPO="https://packagemanager.rstudio.com/cran/__linux__/jammy/2023-03-31+MbiAEzHt"
+ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30"
 RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site"
 
 # install system dependencies


### PR DESCRIPTION
closes #49 

Update CRAN repo pinned data and URL to match that in workflow.transition.monitor (and to enable download of dbplyr >=v2.4.0, a requirement for pacta.portfolio.allocate).

https://github.com/RMI-PACTA/workflow.transition.monitor/blob/f54305fa26117ccf983cd5f858ba8bc502832b4b/Dockerfile#L29