### PR TITLE
build(docker): #57 Build from recent image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,3 @@
-# using rocker r-vers as a base with R 4.2.3
-# https://hub.docker.com/r/rocker/r-ver
-# https://rocker-project.org/images/versioned/r-ver.html
-#
-# sets CRAN repo to use Posit Package Manager to freeze R package versions to
-# those available on 2023-03-31
-# https://packagemanager.rstudio.com/client/#/repos/2/overview
-# https://packagemanager.rstudio.com/cran/__linux__/jammy/2023-03-31+MbiAEzHt
-
 FROM ghcr.io/rmi-pacta/workflow.transition.monitor:main
 # inherit CRAN REPO and R options from base image
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@
 # https://packagemanager.rstudio.com/client/#/repos/2/overview
 # https://packagemanager.rstudio.com/cran/__linux__/jammy/2023-03-31+MbiAEzHt
 
-ARG BASE_IMAGE=transitionmonitordockerregistry.azurecr.io/rmi_pacta:2021q4_1.0.0
-FROM --platform=linux/amd64 $BASE_IMAGE
+FROM ghcr.io/rmi-pacta/workflow.transition.monitor:main
 ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30"
 RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@
 # https://packagemanager.rstudio.com/cran/__linux__/jammy/2023-03-31+MbiAEzHt
 
 FROM ghcr.io/rmi-pacta/workflow.transition.monitor:main
-ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30"
-RUN echo "options(repos = c(CRAN = '$CRAN_REPO'))" >> "${R_HOME}/etc/Rprofile.site"
+# inherit CRAN REPO and R options from base image
 
 # Install R dependencies
 COPY DESCRIPTION /workflow.prepare.pacta.indices/DESCRIPTION

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and format them for the Transition Monitor webtool.
 ### Required input
 
 The index preparation Dockerfile uses the `ghcr.io/rmi-pacta/workflow.transition.monitor` docker image as a base image.
-Although the image is public, pullang public images ffrom GHCR requires authentication.
+Although the image is public, pulling public images from GHCR requires authentication.
 
 You can authenticate to GHCR with any valid GitHub Personal Access token
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,17 @@ The goal of `workflow.prepare.pacta.indices` is to run indices through PACTA,
 and format them for the Transition Monitor webtool. 
 
 ## Running Prepare PACTA Indices workflow  
+
 ### Required input
 
-The index preparation Dockerfile uses the `transitionmonitordockerregistry/rmi_pacta` docker image as a base image. Pulling this image requires access to the Azure docker registry `transitionmonitordockerregistry`. 
+The index preparation Dockerfile uses the `ghcr.io/rmi-pacta/workflow.transition.monitor` docker image as a base image.
+Although the image is public, pullang public images ffrom GHCR requires authentication.
 
-You can log-in to this registry by calling:
+You can authenticate to GHCR with any valid GitHub Personal Access token
+
 ``` bash
-az acr login --name transitionmonitordockerregistry
-``` 
+echo $GITHUB_PAT | docker login ghcr.io -u <USERNAME> --password-stdin
+```
 
 ### Running in Docker
 The simplest way to run the data preparation process is by using docker. 


### PR DESCRIPTION
Build from a recent image from the public registry for `workflow.transition.monitor`. While these images don't include the pacta-data needed to prepare indices, the current README instructions include a requirement to externally mount PACTA-data.

Closes: #57