### PR TITLE
Build/65 remove dotenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN Rscript -e "\
   "
 
 # copy in workflow repo
-COPY prepare_pacta_indices.R .env config.yml /workflow.prepare.pacta.indices/
+COPY prepare_pacta_indices.R config.yml /workflow.prepare.pacta.indices/
 
 WORKDIR /workflow.prepare.pacta.indices
 

--- a/README.md
+++ b/README.md
@@ -19,23 +19,26 @@ You can log-in to this registry by calling:
 az acr login --name transitionmonitordockerregistry
 ``` 
 
-### Running in Docker
-The simplest way to run the data preparation process is by using docker. 
+### Running in `docker-compose`
 
-First, create a `.env` file in the root directory with the following fields: 
+0. *Optional, but recommended.* 
+    Make a `,env` file.
+    This file will preserve the environment variables that control behavior on the host machine, as well as specifying the configuration to use.
+    This file can be replaced or overridden by specifying environment variables on the host machine, or as part of invoking docker.
+    For more information on specifying environment variables to `docker-compose`, please refer to the [documentation](https://docs.docker.com/compose/environment-variables/envvars-precedence/).
+    An example of a `.env` file is:
 
-``` env
-PACTA_DATA_PATH=PATH/TO/pacta-data
-R_CONFIG_ACTIVE=YYYYQQ
-```
-The `R_CONFIG_ACTIVE` variable should point to the appropriate set of 
-configuration values specified in the `config.yml` file. 
+    ``` env
+    PACTA_DATA_PATH=PATH/TO/pacta-data
+    R_CONFIG_ACTIVE=YYYYQQ
+    ```
+    
+    Where `R_CONFIG_ACTIVE` is a top-level key from `config.yml`.
 
-Once these variables have been set, simply run 
+1. Run `docker-compose`
 
-``` bash
-docker-compose up --build
-```
+    ``` bash
+    docker-compose up --build
+    ```
 
-and the prepared indices will automatically populate in the folder 
-`PACTA_DATA_PATH`.
+    which will run the script with the defined configuration, and populate files into the paths specified.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ az acr login --name transitionmonitordockerregistry
 ### Running in `docker-compose`
 
 0. *Optional, but recommended.* 
-    Make a `,env` file.
+    Make a `.env` file.
     This file will preserve the environment variables that control behavior on the host machine, as well as specifying the configuration to use.
     This file can be replaced or overridden by specifying environment variables on the host machine, or as part of invoking docker.
     For more information on specifying environment variables to `docker-compose`, please refer to the [documentation](https://docs.docker.com/compose/environment-variables/envvars-precedence/).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   indices_prep:
     build:
       context: .
-    env_file:
-      - .env
+    environment:
+      - R_CONFIG_ACTIVE=${R_CONFIG_ACTIVE}
     volumes:
       - ${PACTA_DATA_PATH}:/pacta-data

--- a/prepare_pacta_indices.R
+++ b/prepare_pacta_indices.R
@@ -6,9 +6,6 @@ suppressPackageStartupMessages({
   library("readr")
 })
 
-# config
-readRenviron(".env")
-
 config <-
   config::get(
     file = "config.yml",


### PR DESCRIPTION
Remove dependency on .env file, since everything is now controlled by normal envvars.

Closes #65 