### PR TITLE
update target date in 2023Q4 config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -60,7 +60,7 @@ default:
 
 2023Q4:
   pacta_financial_timestamp: "2023Q4"
-  ishares_date: "20231231"
+  ishares_date: "20231229"
   bonds_indices_urls: !expr |- 
     c(
       "iShares Global Corp Bond UCITS ETF <USD (Distributing)>" = 


### PR DESCRIPTION
Use `20231229` for 2023Q4 as it's the closest available date. This is unsurprising because 2023-12-31 and 2023-12-30 were weekend end days / bank holidays. Similar to the 2022Q4, which uses `20221230` because 2022-12-31 was a weekend / holiday.

closes #68