### PR TITLE
ci(docker): #55 Mark inputs directory as read-only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
       - type: bind
         source: ${PACTA_DATA_PATH}
         target: /pacta-data/${R_CONFIG_ACTIVE}
+        read_only: true
       - type: bind
         source: ${INDICES_PREPARATION_OUTPUTS_PATH:-./outputs}
         # target must be kept in sync with config.yml
         target: /mnt/outputs
+        read_only: false


### PR DESCRIPTION
update docker-compose such that the inputs (`pacta-data`) directory is read-only, while write is permitted for outputs

Closes: #55