### PR TITLE
feat: gains PA2024CH config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -58,7 +58,8 @@ default:
       "https://www.ishares.com/uk/individual/en/products/251850/ishares-msci-acwi-ucits-etf/"
     )
 
-2023Q4:
+PA2024CH:
+  project_code: "PA2024CH"
   pacta_financial_timestamp: "2023Q4"
   ishares_date: "20231229"
   bonds_indices_urls: !expr |-


### PR DESCRIPTION
After #81, `main.R` now expects a `project_code` in the `config.yml` (which it uses to select the appropriate `ProjectParmeters` file in https://github.com/RMI-PACTA/workflow.transition.monitor

Since we want to pull the `PA2024CH` project_code (and I didn't want to have that value appear in a general `2023Q4` config), I made a more specific `PA2024CH` section in the config.

Note: This will require a change in the `.env` file to run appropriately.  