### PR TITLE
hotfix: rename PA2024CH config -> 2023Q4

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -58,7 +58,7 @@ default:
       "https://www.ishares.com/uk/individual/en/products/251850/ishares-msci-acwi-ucits-etf/"
     )
 
-PA2024CH:
+2023Q4:
   project_code: "PA2024CH"
   pacta_financial_timestamp: "2023Q4"
   ishares_date: "20231229"


### PR DESCRIPTION
This is not the most ideal solution for me, since I don't like the idea of having `project_code:  "PA2024CH"` living under a general `2023Q4` header, but given the deadlines, this hotfix will "work". 

Relates to #87 
Relates to #63