### PR TITLE
remove version specification from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   indices_prep:
     build:


### PR DESCRIPTION
It is obsolete
https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional