### PR TITLE
Rename workflow job

### DIFF
--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -1,5 +1,5 @@
 ---
-name: Run scenario preparation
+name: Run Index preparation
 
 # This workflow is based on, but diverges from the example here:
 # https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
@@ -26,7 +26,7 @@ on:
 
 jobs:
   prep:
-    name: Run workflow
+    name: Run Index Preparation
     runs-on: ubuntu-latest
     timeout-minutes: 45
     # write to packages (ghcr.io)


### PR DESCRIPTION
When calling workflow from another repo, the workflow simply reads "Run workflow". This provides a more informative label.

![Screenshot_2024-05-08_14 59 28](https://github.com/RMI-PACTA/workflow.prepare.pacta.indices/assets/2974734/8a3cd0d8-8acf-4d71-9863-2d88c94c002c)
