### PR TITLE
add config as a dependency to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.0
 Imports: 
+    config,
     dplyr,
     fs,
     logger,


### PR DESCRIPTION
because it's used in [main.R](https://github.com/RMI-PACTA/workflow.prepare.pacta.indices/blob/51600e1b85bc9028a65958e61ab7c83b34d8aa87/main.R#L15-L21)