### PR TITLE
feat: update `config.yml` to point to latest benchmark input data

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,4 +11,4 @@ default:
 2023Q4:
   project_code: "PA2024CH"
   pacta_financial_timestamp: "2023Q4"
-  benchmark_inputs_filename: "2023Q4_benchmark_portfolios_20240607-110113.rds"
+  benchmark_inputs_filename: "2023Q4_benchmark_portfolios_20240717-002743.rds"


### PR DESCRIPTION
The configuration currently points to benchmark input data containing both the real MSCI data and MSCI ETF data. 

It was decided in https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_workitems/edit/11078/ to only include ETF data if there was no real index data.

This was implemented here: https://github.com/RMI-PACTA/workflow.benchmark.preparation/pull/6

But requires a similar change in the configuration file, that this PR hopes to address. 

Likely closes:
https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_workitems/edit/11076 and
https://dev.azure.com/RMI-PACTA/2DegreesInvesting/_workitems/edit/11078