### PR TITLE
Check if results exist prior to running index prep process

### DIFF
--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -161,11 +161,13 @@ jobs:
       - name: Upload Results
         id: upload-results
         uses: azure/CLI@v2
+        env:
+          overall_md5: ${{ steps.hash-files.outputs.overall-md5 }}
         with:
           # azcliversion: 2.30.0
           inlineScript: |
             outputs_dir="outputs"
-            timestamp_dir="$(ls $outputs_dir)"
+            timestamp_dir="$overall_md5/$(ls $outputs_dir)"
             echo "timestamp-dir=$timestamp_dir"
             echo "timestamp-dir=$timestamp_dir" >> "$GITHUB_OUTPUT"
             workflow_index_outputs_afs_path="https://pactadatadev.file.core.windows.net/workflow-prepare-pacta-indices-outputs"

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -118,7 +118,7 @@ jobs:
         id: check-exist
         uses: azure/CLI@v2
         env:
-          overall_md5: ${{ steps.hash-files.outpus.overall-md5 }}
+          overall_md5: ${{ steps.hash-files.outputs.overall-md5 }}
         with:
           # azcliversion: 2.30.0
           inlineScript: |
@@ -133,7 +133,7 @@ jobs:
             echo "files-exist=$files_exist" >> "$GITHUB_OUTPUT"
 
       - name: build image
-        if: ${{ steps.check-exist.outputs.files-exist != true }}
+        if: ${{ steps.check-exist.outputs.files-exist != 'true' }}
         env:
           base_tag: ${{ inputs.image-tag }}
         run: |
@@ -141,13 +141,13 @@ jobs:
           docker-compose build --build-arg="BASE_TAG=$base_tag" -t pacta-index-prep:$base_tag .
 
       - name: run container
-        if: ${{ steps.check-exist.outputs.files-exist != true }}
+        if: ${{ steps.check-exist.outputs.files-exist != 'true' }}
         run: |
           docker-compose up
 
       # https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended
       - name: Azure Login
-        if: ${{ steps.check-exist.outputs.files-exist != true }}
+        if: ${{ steps.check-exist.outputs.files-exist != 'true' }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -24,9 +24,9 @@ on:
         required: false
         type: string
     outputs:
-      timestamp-dir:
+      results-dir:
         description: "Timestamped directory of workflow outputs"
-        value: ${{ jobs.prep.outputs.timestamp-dir }}
+        value: ${{ jobs.prep.outputs.results-dir }}
 
 jobs:
   prep:
@@ -39,7 +39,7 @@ jobs:
       contents: read
       id-token: write
     outputs:
-      timestamp-dir: ${{ steps.export-outputs.outputs.timestamp-dir }}
+      timestamp-dir: ${{ steps.export-outputs.outputs.results-dir }}
 
     steps:
 
@@ -181,11 +181,15 @@ jobs:
           # azcliversion: 2.30.0
           inlineScript: |
             outputs_dir="outputs"
-            timestamp_dir="$overall_md5/$(ls $outputs_dir)"
+            timestamp_dir="$(ls $outputs_dir)"
             echo "timestamp-dir=$timestamp_dir"
-            workflow_index_outputs_afs_path="https://pactadatadev.file.core.windows.net/workflow-prepare-pacta-indices-outputs/$overall_md5"
+            results_dir="$overall_md5"
+            mkdir "$results_dir"
+            mv "$outputs_dir/$timestamp_dir/* "$results_dir"
+            ls "$results_dir"
+            workflow_index_outputs_afs_path="https://pactadatadev.file.core.windows.net/workflow-prepare-pacta-indices-outputs"
             az storage copy \
-              --source $outputs_dir/* \
+              --source "$results_dir" \
               --destination "$workflow_index_outputs_afs_path" \
               --recursive
 
@@ -194,7 +198,5 @@ jobs:
         env:
           overall_md5: ${{ steps.hash-files.outputs.overall-md5 }}
         run: |
-            outputs_dir="outputs"
-            timestamp_dir="$overall_md5/$(ls $outputs_dir)"
-            echo "timestamp-dir=$timestamp_dir"
-            echo "timestamp-dir=$timestamp_dir" >> "$GITHUB_OUTPUT"
+            echo "results-dir=$overall_md5"
+            echo "results-dir=$overall_md5" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -104,7 +104,7 @@ jobs:
           config_active: ${{ inputs.config_active }}
         run: |
           tmpfile=$(mktemp)
-          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /usr/local/lib/R/ -type f -exec md5sum {} \; >> "$tmpfile"
+          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} Rscript -e "jsonlite::toJSON(pacta.workflow.utils:::get_package_info(as.data.frame(installed.packages())[['Package']]), auto_unbox = TRUE, pretty = TRUE)" | jq 'map(del(.built))' >> "$tmpfile"
           docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /bound -type f -exec md5sum {} \; >> "$tmpfile"
           docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /pacta-data -type f -exec md5sum {} \; >> "$tmpfile"
           md5sum .env >> $tmpfile

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -182,7 +182,7 @@ jobs:
             echo "timestamp-dir=$timestamp_dir"
             results_dir="$overall_md5"
             mkdir "$results_dir"
-            mv "$outputs_dir/$timestamp_dir/* "$results_dir"
+            mv $outputs_dir/$timestamp_dir/* "$results_dir"
             ls "$results_dir"
             workflow_index_outputs_afs_path="https://pactadatadev.file.core.windows.net/workflow-prepare-pacta-indices-outputs"
             az storage copy \

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -179,7 +179,7 @@ jobs:
             timestamp_dir="$overall_md5/$(ls $outputs_dir)"
             echo "timestamp-dir=$timestamp_dir"
             echo "timestamp-dir=$timestamp_dir" >> "$GITHUB_OUTPUT"
-            workflow_index_outputs_afs_path="https://pactadatadev.file.core.windows.net/workflow-prepare-pacta-indices-outputs"
+            workflow_index_outputs_afs_path="https://pactadatadev.file.core.windows.net/workflow-prepare-pacta-indices-outputs/$overall_md5"
             az storage copy \
               --source $outputs_dir/* \
               --destination "$workflow_index_outputs_afs_path" \

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -98,6 +98,7 @@ jobs:
           docker pull ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag}
 
       - name: Hash files
+        id: hash-files
         env:
           base_tag: ${{ inputs.image-tag }}
         run: |
@@ -113,8 +114,26 @@ jobs:
           echo "overall-md5=$overall_md5"
           echo "overall-md5=$overall_md5" >> "$GITHUB_OUTPUT"
 
+      - name: Check if results exist
+        id: check-exist
+        uses: azure/CLI@v2
+        env:
+          overall_md5: ${{ steps,.hash-files.outpus.overall-md5 }}
+        with:
+          # azcliversion: 2.30.0
+          inlineScript: |
+            files_exist=$(
+              az storage directory exists \
+                --name "$overall_md5" \
+                --share-name "workflow-prepare-pacta-indices-outputs" \
+                --account-name "pactadatadev" |
+                jq -rc '.exists'
+            )
+            echo "files-exist=$files_exist"
+            echo "files-exist=$files_exist" >> "$GITHUB_OUTPUT"
 
       - name: build image
+        if: ${{ steps.check-exist.outputs.files-exist != true }}
         env:
           base_tag: ${{ inputs.image-tag }}
         run: |
@@ -122,11 +141,13 @@ jobs:
           docker-compose build --build-arg="BASE_TAG=$base_tag" -t pacta-index-prep:$base_tag .
 
       - name: run container
+        if: ${{ steps.check-exist.outputs.files-exist != true }}
         run: |
           docker-compose up
 
       # https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended
       - name: Azure Login
+        if: ${{ steps.check-exist.outputs.files-exist != true }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -135,6 +156,7 @@ jobs:
 
       # https://github.com/marketplace/actions/azure-cli-action#workflow-to-execute-an-azure-cli-script-of-a-specific-cli-version
       - name: Upload Results
+        if: ${{ steps.check-exist.outputs.files-exist != true }}
         id: upload-results
         uses: azure/CLI@v2
         with:

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -109,6 +109,9 @@ jobs:
           md5sum .env >> $tmpfile
           find pacta-data/ -type f -exec md5sum {} \; >> "$tmpfile"
           find inputs/ -type f -exec md5sum {} \; >> "$tmpfile"
+          md5sum DESCRIPTION >> "$tmpfile"
+          md5sum config.yml >> "$tmpfile"
+          md5sum main.R >> "$tmpfile"
           cat $tmpfile
           overall_md5=$(md5sum "$tmpfile" | awk '{ print $1 }')
           echo "overall-md5=$overall_md5"

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -35,7 +35,7 @@ jobs:
       contents: read
       id-token: write
     outputs:
-      timestamp-dir: ${{ steps.export-outputs.outputs.results-dir }}
+      results-dir: ${{ steps.export-outputs.outputs.results-dir }}
 
     steps:
 

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -102,19 +102,19 @@ jobs:
           base_tag: ${{ inputs.image-tag }}
         run: |
           tmpfile=$(mktemp)
-          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /usr/local/lib/R/ -type f -exec md5sum {} \; > "$tmpfile"
-          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /bound -type f -exec md5sum {} \; > "$tmpfile"
-          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /pacta-data -type f -exec md5sum {} \; > "$tmpfile"
-          md5sum .env
-          find pacta-data/ -type f -exec md5sum {} \; > "$tmpfile"
-          find inputs/ -type f -exec md5sum {} \; > "$tmpfile"
+          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /usr/local/lib/R/ -type f -exec md5sum {} \; >> "$tmpfile"
+          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /bound -type f -exec md5sum {} \; >> "$tmpfile"
+          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /pacta-data -type f -exec md5sum {} \; >> "$tmpfile"
+          md5sum .env >> $tmpfile
+          find pacta-data/ -type f -exec md5sum {} \; >> "$tmpfile"
+          find inputs/ -type f -exec md5sum {} \; >> "$tmpfile"
           cat $tmpfile
           overall_md5=$(md5sum "$tmpfile")
           echo "overall-md5=$overall_md5"
           echo "overall-md5=$overall_md5" >> "$GITHUB_OUTPUT"
 
 
-      - name: run container
+      - name: build image
         env:
           base_tag: ${{ inputs.image-tag }}
         run: |

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -91,6 +91,29 @@ jobs:
           mkdir "outputs"
           cat .env
 
+      - name: pull Docker base image
+        env:
+          base_tag: ${{ inputs.image-tag }}
+        run: |
+          docker pull ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag}
+
+      - name: Hash files
+        env:
+          base_tag: ${{ inputs.image-tag }}
+        run: |
+          tmpfile=$(mktemp)
+          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /usr/local/lib/R/ -type f -exec md5sum {} \; > "$tmpfile"
+          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /bound -type f -exec md5sum {} \; > "$tmpfile"
+          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /pacta-data -type f -exec md5sum {} \; > "$tmpfile"
+          md5sum .env
+          find pacta-data/ -type f -exec md5sum {} \; > "$tmpfile"
+          find inputs/ -type f -exec md5sum {} \; > "$tmpfile"
+          cat $tmpfile
+          overall_md5=$(md5sum "$tmpfile")
+          echo "overall-md5=$overall_md5"
+          echo "overall-md5=$overall_md5" >> "$GITHUB_OUTPUT"
+
+
       - name: run container
         env:
           base_tag: ${{ inputs.image-tag }}

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -35,7 +35,7 @@ jobs:
       contents: read
       id-token: write
     outputs:
-      timestamp-dir: ${{ steps.upload-results.outputs.timestamp-dir }}
+      timestamp-dir: ${{ steps.export-outputs.outputs.timestamp-dir }}
 
     steps:
 
@@ -169,6 +169,7 @@ jobs:
       # https://github.com/marketplace/actions/azure-cli-action#workflow-to-execute-an-azure-cli-script-of-a-specific-cli-version
       - name: Upload Results
         id: upload-results
+        if: ${{ steps.check-exist.outputs.files-exist != 'true' }}
         uses: azure/CLI@v2
         env:
           overall_md5: ${{ steps.hash-files.outputs.overall-md5 }}
@@ -178,9 +179,18 @@ jobs:
             outputs_dir="outputs"
             timestamp_dir="$overall_md5/$(ls $outputs_dir)"
             echo "timestamp-dir=$timestamp_dir"
-            echo "timestamp-dir=$timestamp_dir" >> "$GITHUB_OUTPUT"
             workflow_index_outputs_afs_path="https://pactadatadev.file.core.windows.net/workflow-prepare-pacta-indices-outputs/$overall_md5"
             az storage copy \
               --source $outputs_dir/* \
               --destination "$workflow_index_outputs_afs_path" \
               --recursive
+
+      - name: export-outputs
+        id: export-outputs
+        env:
+          overall_md5: ${{ steps.hash-files.outputs.overall-md5 }}
+        run: |
+            outputs_dir="outputs"
+            timestamp_dir="$overall_md5/$(ls $outputs_dir)"
+            echo "timestamp-dir=$timestamp_dir"
+            echo "timestamp-dir=$timestamp_dir" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -19,6 +19,10 @@ on:
         description: active config from config.yml
         required: true
         type: string
+      artifact-key:
+        description: key to disambiguate artifacts
+        required: false
+        type: string
     outputs:
       timestamp-dir:
         description: "Timestamped directory of workflow outputs"
@@ -122,7 +126,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.config_active }}-${{ inputs.image-tag }}
+          name: ${{ inputs.config_active }}-${{ inputs.image-tag }}-${{ inputs.artifact-key }}
           path: ${{ steps.hash-files.outputs.hashfile }}
           if-no-files-found: error
 

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -19,10 +19,6 @@ on:
         description: active config from config.yml
         required: true
         type: string
-      artifact-key:
-        description: key to disambiguate artifacts
-        required: false
-        type: string
     outputs:
       results-dir:
         description: "Timestamped directory of workflow outputs"
@@ -126,9 +122,10 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.config_active }}-${{ inputs.image-tag }}-${{ inputs.artifact-key }}
+          name: ${{ inputs.config_active }}-${{ steps.hash-files.outputs.overall-md5 }}
           path: ${{ steps.hash-files.outputs.hashfile }}
           if-no-files-found: error
+          overwrite: true
 
       - name: Check if results exist
         id: check-exist

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -104,7 +104,6 @@ jobs:
           config_active: ${{ inputs.config_active }}
         run: |
           tmpfile=$(mktemp)
-          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} Rscript -e "jsonlite::toJSON(pacta.workflow.utils:::get_package_info(as.data.frame(installed.packages())[['Package']]), auto_unbox = TRUE, pretty = TRUE)" | jq 'map(del(.built))' >> "$tmpfile"
           docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /bound -type f -exec md5sum {} \; >> "$tmpfile"
           docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /pacta-data -type f -exec md5sum {} \; >> "$tmpfile"
           md5sum .env >> $tmpfile
@@ -114,6 +113,7 @@ jobs:
           md5sum config.yml >> "$tmpfile"
           md5sum main.R >> "$tmpfile"
           sort -o "$tmpfile" -k2 "$tmpfile"
+          docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} Rscript -e "pak::pak('RMI-PACTA/pacta.workflow.utils'); jsonlite::toJSON(pacta.workflow.utils:::get_package_info(as.data.frame(installed.packages())[['Package']]), auto_unbox = TRUE, pretty = TRUE)" | jq 'map(del(.built))' >> "$tmpfile"
           cat $tmpfile
           overall_md5=$(md5sum "$tmpfile" | awk '{ print $1 }')
           echo "overall-md5=$overall_md5"

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -122,6 +122,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: ${{ inputs.config_active }}-${{ inputs.image-tag }}
           path: ${{ steps.hash-files.outputs.hashfile }}
           if-no-files-found: error
 

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -101,6 +101,7 @@ jobs:
         id: hash-files
         env:
           base_tag: ${{ inputs.image-tag }}
+          config_active: ${{ inputs.config_active }}
         run: |
           tmpfile=$(mktemp)
           docker run --rm ghcr.io/rmi-pacta/workflow.transition.monitor:${base_tag} find /usr/local/lib/R/ -type f -exec md5sum {} \; >> "$tmpfile"
@@ -116,6 +117,12 @@ jobs:
           overall_md5=$(md5sum "$tmpfile" | awk '{ print $1 }')
           echo "overall-md5=$overall_md5"
           echo "overall-md5=$overall_md5" >> "$GITHUB_OUTPUT"
+          echo "hashfile=$tmpfile" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ${{ steps.hash-files.outputs.hashfile }}
+          if-no-files-found: error
 
       - name: Check if results exist
         id: check-exist

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -109,7 +109,7 @@ jobs:
           find pacta-data/ -type f -exec md5sum {} \; >> "$tmpfile"
           find inputs/ -type f -exec md5sum {} \; >> "$tmpfile"
           cat $tmpfile
-          overall_md5=$(md5sum "$tmpfile")
+          overall_md5=$(md5sum "$tmpfile" | awk '{ print $1 }')
           echo "overall-md5=$overall_md5"
           echo "overall-md5=$overall_md5" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -118,7 +118,7 @@ jobs:
         id: check-exist
         uses: azure/CLI@v2
         env:
-          overall_md5: ${{ steps,.hash-files.outpus.overall-md5 }}
+          overall_md5: ${{ steps.hash-files.outpus.overall-md5 }}
         with:
           # azcliversion: 2.30.0
           inlineScript: |
@@ -156,7 +156,6 @@ jobs:
 
       # https://github.com/marketplace/actions/azure-cli-action#workflow-to-execute-an-azure-cli-script-of-a-specific-cli-version
       - name: Upload Results
-        if: ${{ steps.check-exist.outputs.files-exist != true }}
         id: upload-results
         uses: azure/CLI@v2
         with:

--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -113,6 +113,7 @@ jobs:
           md5sum DESCRIPTION >> "$tmpfile"
           md5sum config.yml >> "$tmpfile"
           md5sum main.R >> "$tmpfile"
+          sort -o "$tmpfile" -k2 "$tmpfile"
           cat $tmpfile
           overall_md5=$(md5sum "$tmpfile" | awk '{ print $1 }')
           echo "overall-md5=$overall_md5"


### PR DESCRIPTION
Currently, a big time sink in the `workflow.transition.monitor` dev cycle is waiting for the index prep process to run (~25 min that blocks building the "final" images). The process runs on each push, which ensures that the prepared benchmark results that go into the image are "in-sync" and generated by the code that is in that docker image, but also imposes a big penalty on development of non-benchmark relevant work.

This PR works around that, by generating a hash of relevant files, and then checking if a corresponding result set has already been created and uploaded to AFS.

Specifically, the workflow checks the md5 hashes of all files in:
* `.env` used to run the workflow
* `pacta-data` downloaded from AFS
* `inputs`: the benchmark portfolios generated by `workflow.benchmark.preparation`
* `DESCRIPTION`, `config.yml`, `and `main.R` from this repo
* The outputs of running `pacta.workflow.utils:::get_package_info()` against all packages installed inside the Docker image (mostly, it ignores the `built` component, since that isn't stable even against the P3M date-pinned repos).
* `/pacta-data/` inside the docker image (which should be empty)
* `/bound/` from inside the image, which. captures the relevant files from `workflow.transition.monitor`

These individual file md5s are then sorted, and an "overall" md5 is taken of these hashes.

If the result files already exist on AFS, then this workflow bypasses running the results, and simply returns the path to the files, as normal. Otherwise, it runs the prep process and then uploads the results to AFS (previous behavior)

The biggest change is in storage and location of the files on AFS, which previously would have been at a timestamped directory, but now the data is located underneath a directory named as the md5 hash described above:

Before: `2022Q4_20240724T103354Z/Indices_bonds_audit.rds`
After: `34b1b029fe0464109d263b92cd5a6285/Indices_bonds_audit.rds`

### Notes for reviewers

Note that this change in the worst case yields run times approximately what they are now. When making changes that don't affect the installed packages in `workflow.transition.monitor` docker image (or in the docker-relevant code for that repo, see `.dockerignore.CIbuild` in https://github.com/RMI-PACTA/workflow.transition.monitor/pull/338), then we'll get a cache hit, and the index prep section of the pipeline is _much quicker_, but it should never be worse than what it is now.

I expect that the most common thing that will invalidate the index-prep cache here is updates to the `pacta.*` packages (but obviously changes tot he pacta-data or benchmark portfolio files will too). Note that the `templates.transition.monitor` repo isn't in-scope for the caching mechanism, so "text-only" changes should be a lot quicker to render.

The process will almost certainly run in full on the first run of any new PR, but there's a lot of potential for subsequent build in the same PR to be quicker.