### PR TITLE
Filter so only portfolios with expected asset class are included

### DIFF
--- a/main.R
+++ b/main.R
@@ -248,11 +248,32 @@ for (portfolio_name in portfolio_names) {
 
 # -------------------------------------------------------------------------
 
-output_files <- list.files(
-  temporary_directory,
-  pattern = "*_portfolio[.]rds$",
-  full.names = TRUE
-)
+output_files <- tibble::tibble(
+  path = list.files(
+    temporary_directory,
+    pattern = "*_portfolio[.]rds$",
+    full.names = TRUE
+  )
+) %>%
+  dplyr::mutate(
+    port_type = dplyr::case_when(
+      grepl(pattern = "_Bonds_", x = path, fixed = TRUE) ~ "Bonds",
+      grepl(pattern = "_Equity_", x = path, fixed = TRUE) ~ "Equity",
+      TRUE ~ NA_character_
+    )
+  ) %>%
+  dplyr::mutate(
+    expected_port_type = dplyr::if_else(
+      condition = grepl(pattern = "Global Corp Bond", x = path, fixed = TRUE),
+      true = "Bonds",
+      false = "Equity"
+    )
+  ) %>%
+  dplyr::filter(
+    port_type == expected_port_type
+  ) %>%
+  dplyr::pull(path)
+
 
 logger::log_info("Combining results files.")
 combined <-


### PR DESCRIPTION
This PR adds a filter to ensure that:

Only corporate bond holdings are included for:
    CB, "iShares Global Corp Bond UCITS ETF",

and only equity holdings are included for:
    EQ, "iShares Core S&P 500 ETF",
    EQ, "iShares MSCI World ETF",
    EQ,  "iShares MSCI Emerging Markets ETF",
    EQ, "iShares MSCI ACWI ETF",