### PR TITLE
fix: don't require `REPO_PAT` to checkout GH action

### DIFF
--- a/.github/workflows/run-index-preparation.yml
+++ b/.github/workflows/run-index-preparation.yml
@@ -43,7 +43,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: RMI-PACTA/workflow.prepare.pacta.indices
-          token: ${{ secrets.REPO_PAT }}
 
       # https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended
       - name: Azure Login


### PR DESCRIPTION
This action is currently failing. 

On the one hand, `REPO_PAT` has expired. 
On the other hand, this repository is public, so I don't even think it's necessary to run the `checkout` action. 

I am removing it here to see if that fixes the problem.